### PR TITLE
Gui/quiz questions

### DIFF
--- a/informed-consent/quiz.md
+++ b/informed-consent/quiz.md
@@ -5,58 +5,58 @@ ooniprobe!
 
 ## Which of the following statements is true?
 
-[] OONI software tests are designed to detect censorship and surveillance
+[ ] OONI software tests are designed to detect censorship and surveillance
 
-[] OONI software tests are designed to detect censorship and signs of
+[ ] OONI software tests are designed to detect censorship and signs of
  surveillance
 
-[] OONI software tests allow users to circumvent censorship
+[ ] OONI software tests allow users to circumvent censorship
 
-[] OONI software tests allow users to circumvent censorship and surveillance
-
-## Which of the following statements is true?
-
-[] ooniprobe is run over Tor, thus protecting my privacy
-
-[] ooniprobe is not run over Tor, but is still designed to protect my privacy
-
-[] ooniprobe is not run over Tor, but measurements can get sent over Tor
-
-[] ooniprobe measurements are sent over Tor, thus protecting my privacy
+[ ] OONI software tests allow users to circumvent censorship and surveillance
 
 ## Which of the following statements is true?
 
-[] Anyone monitoring my internet activity (e.g. ISP, government or employer)
+[ ] ooniprobe is run over Tor, thus protecting my privacy
+
+[ ] ooniprobe is not run over Tor, but is still designed to protect my privacy
+
+[ ] ooniprobe is not run over Tor, but measurements can get sent over Tor
+
+[ ] ooniprobe measurements are sent over Tor, thus protecting my privacy
+
+## Which of the following statements is true?
+
+[ ] Anyone monitoring my internet activity (e.g. ISP, government or employer)
  might be able to see that I am running ooniprobe
 
-[] Anyone monitoring my internet activity (e.g. ISP, government or employer)
+[ ] Anyone monitoring my internet activity (e.g. ISP, government or employer)
  will *not* be able to see that I am running ooniprobe, because ooniprobe is
  run over Tor
 
-[] Anyone monitoring my internet activity (e.g. ISP, government or employer)
+[ ] Anyone monitoring my internet activity (e.g. ISP, government or employer)
  will *not* be able to see that I am running ooniprobe, because the
  measurements are sent over Tor
 
 ## Which of the following statements is true?
 
-[] Once I have run ooniprobe, I need to configure my settings to send my
+[ ] Once I have run ooniprobe, I need to configure my settings to send my
  measurements to OONI
 
-[] My measurements will by default get sent to OONI and published on OONI
+[ ] My measurements will by default get sent to OONI and published on OONI
  Explorer
 
-[] My measurements will by default get sent to OONI, but they won't by default
+[ ] My measurements will by default get sent to OONI, but they won't by default
  get published on OONI Explorer
 
 ## Which of the following statements is true?
 
-[] My IP address and other potentially personally-identifiable information will
+[ ] My IP address and other potentially personally-identifiable information will
  be published on OONI Explorer
 
-[] Some of my potentially personally-identifiable information will be published
+[ ] Some of my potentially personally-identifiable information will be published
  on OONI Explorer
 
-[] My IP address will be published on OONI Explorer
+[ ] My IP address will be published on OONI Explorer
 
-[] My IP address and other potentially personally-identifiable information might
+[ ] My IP address and other potentially personally-identifiable information might
  unintentionally be published on OONI Explorer

--- a/informed-consent/quiz.md
+++ b/informed-consent/quiz.md
@@ -1,7 +1,8 @@
 # Quiz
 
-Please answer the questions of the following quiz correctly to get started with
-ooniprobe!
+Please answer the following questions to ensure that you have understood what
+ooniprobe does and that you are aware of risks associated with running the
+software.
 
 ## In regards to how detectable ooniprobe is, which of the following statements
 ## is true?
@@ -11,7 +12,8 @@ ooniprobe!
  precautions to make this hard
 
 [ ] Anyone monitoring my internet activity (e.g. ISP, government or employer)
- will *not* be able to see that I am running ooniprobe
+will *not* be able to see that I am running ooniprobe, since I am running it
+over a VPN
 
 [] ooniprobe is designed to protect my privacy and therefore my use of ooniprobe
  cannot be detected
@@ -22,8 +24,8 @@ ooniprobe!
 
 [ ] My measurements will *not* by default get published on OONI Explorer
 
-[ ] My measurements will by default get published on OONI  Explorer and might
+[ ] My measurements will by default get published on OONI Explorer and might
  include personally-identifiable information
 
-[ ] My measurements will by default get published to OONI Explorer and will
+[ ] My measurements will by default get published on OONI Explorer and will
  never include any personally-identifiable information

--- a/informed-consent/quiz.md
+++ b/informed-consent/quiz.md
@@ -1,0 +1,62 @@
+# Quiz
+
+Please answer the questions of the following quiz correctly to get started with
+ooniprobe!
+
+## Which of the following statements is true?
+
+[] OONI software tests are designed to detect censorship and surveillance
+
+[] OONI software tests are designed to detect censorship and signs of
+ surveillance
+
+[] OONI software tests allow users to circumvent censorship
+
+[] OONI software tests allow users to circumvent censorship and surveillance
+
+## Which of the following statements is true?
+
+[] ooniprobe is run over Tor, thus protecting my privacy
+
+[] ooniprobe is not run over Tor, but is still designed to protect my privacy
+
+[] ooniprobe is not run over Tor, but measurements can get sent over Tor
+
+[] ooniprobe measurements are sent over Tor, thus protecting my privacy
+
+## Which of the following statements is true?
+
+[] Anyone monitoring my internet activity (e.g. ISP, government or employer)
+ might be able to see that I am running ooniprobe
+
+[] Anyone monitoring my internet activity (e.g. ISP, government or employer)
+ will *not* be able to see that I am running ooniprobe, because ooniprobe is
+ run over Tor
+
+[] Anyone monitoring my internet activity (e.g. ISP, government or employer)
+ will *not* be able to see that I am running ooniprobe, because the
+ measurements are sent over Tor
+
+## Which of the following statements is true?
+
+[] Once I have run ooniprobe, I need to configure my settings to send my
+ measurements to OONI
+
+[] My measurements will by default get sent to OONI and published on OONI
+ Explorer
+
+[] My measurements will by default get sent to OONI, but they won't by default
+ get published on OONI Explorer
+
+## Which of the following statements is true?
+
+[] My IP address and other potentially personally-identifiable information will
+ be published on OONI Explorer
+
+[] Some of my potentially personally-identifiable information will be published
+ on OONI Explorer
+
+[] My IP address will be published on OONI Explorer
+
+[] My IP address and other potentially personally-identifiable information might
+ unintentionally be published on OONI Explorer

--- a/informed-consent/quiz.md
+++ b/informed-consent/quiz.md
@@ -3,60 +3,27 @@
 Please answer the questions of the following quiz correctly to get started with
 ooniprobe!
 
-## Which of the following statements is true?
-
-[ ] OONI software tests are designed to detect censorship and surveillance
-
-[ ] OONI software tests are designed to detect censorship and signs of
- surveillance
-
-[ ] OONI software tests allow users to circumvent censorship
-
-[ ] OONI software tests allow users to circumvent censorship and surveillance
-
-## Which of the following statements is true?
-
-[ ] ooniprobe is run over Tor, thus protecting my privacy
-
-[ ] ooniprobe is not run over Tor, but is still designed to protect my privacy
-
-[ ] ooniprobe is not run over Tor, but measurements can get sent over Tor
-
-[ ] ooniprobe measurements are sent over Tor, thus protecting my privacy
-
-## Which of the following statements is true?
+## In regards to how detectable ooniprobe is, which of the following statements
+## is true?
 
 [ ] Anyone monitoring my internet activity (e.g. ISP, government or employer)
- might be able to see that I am running ooniprobe
+ might be able to see that I am running ooniprobe, even though OONI takes
+ precautions to make this hard
 
 [ ] Anyone monitoring my internet activity (e.g. ISP, government or employer)
- will *not* be able to see that I am running ooniprobe, because ooniprobe is
- run over Tor
+ will *not* be able to see that I am running ooniprobe
 
-[ ] Anyone monitoring my internet activity (e.g. ISP, government or employer)
- will *not* be able to see that I am running ooniprobe, because the
- measurements are sent over Tor
+[] ooniprobe is designed to protect my privacy and therefore my use of ooniprobe
+ cannot be detected
 
-## Which of the following statements is true?
 
-[ ] Once I have run ooniprobe, I need to configure my settings to send my
- measurements to OONI
+## In regards to the publication of measurements, which of the following
+## statements is true?
 
-[ ] My measurements will by default get sent to OONI and published on OONI
- Explorer
+[ ] My measurements will *not* by default get published on OONI Explorer
 
-[ ] My measurements will by default get sent to OONI, but they won't by default
- get published on OONI Explorer
+[ ] My measurements will by default get published on OONI  Explorer and might
+ include personally-identifiable information
 
-## Which of the following statements is true?
-
-[ ] My IP address and other potentially personally-identifiable information will
- be published on OONI Explorer
-
-[ ] Some of my potentially personally-identifiable information will be published
- on OONI Explorer
-
-[ ] My IP address will be published on OONI Explorer
-
-[ ] My IP address and other potentially personally-identifiable information might
- unintentionally be published on OONI Explorer
+[ ] My measurements will by default get published to OONI Explorer and will
+ never include any personally-identifiable information


### PR DESCRIPTION
These quiz questions could be included in the 'informed consent' wizard that appears right before users can get started with the GUI. Users would have to get these questions right as a prerequisite to installing and running ooniprobe. 

First the wizard would include the 'informed consent' documentation that users would have to read and consent to. Then, once they're provided their consent, they would have to answer the 5 quiz questions correctly. Once they've done this, they can then start installing ooniprobe and running tests of their choice via the GUI. 

These quiz questions were developed with the aim of addressing the following:
1. Checking whether users understand what OONI software tests are designed to do
2. Checking whether users understand associated potential risks
3. Checking whether users understand that by running OONI tests via the GUI, their measurements will by default get published (which might also potentially include risks)

All feedback would really be appreciated! :)

Thanks.
