### PR TITLE
Adds techniques from PATHspider

### DIFF
--- a/techniques/tq-xxx-attempt-ecn.md
+++ b/techniques/tq-xxx-attempt-ecn.md
@@ -1,0 +1,57 @@
+# tq-xxx Attempt use of Explicit Congestion Notification
+
+When a transparent HTTP or TLS proxy is in the path between the probe and the
+target server, an attempt to use explicit congestion notification (ECN) may
+reveal its presence in following ways:
+
+1. The connection fails due to unknown TCP flags being set
+2. The connection fails due to unknown IP flags being set
+3. ECN is not negotiated where expected, or is negotiated where it is not
+   expected
+
+## Methodology
+
+1. Fetch a webpage from a target server using either HTTP or HTTPS, negotiating
+   ECN.
+3. If the first connection failed, retry the request without attempting to
+   negotiate ECN to confirm that this was responsible for the connectivity
+   failure, and not just that the host was down
+
+## Implementation issues
+
+- To use ECN on Linux, it is necessary to enable a sysctl switch in the kernel
+  which would typically require root access. This also affects *all* new
+  connections and so this test should not be scheduled to run in parallel with
+  other tests. A userland TCP stack would be able to implement per-connection
+  ECN logic, but would require raw sockets.
+- To confirm that ECN usage was successful it is necessary to perform a packet
+  capture, while connectivity failures can be confirmed from the application
+  layer feedback alone
+- Analysis of raw packets, and also setting the flags for TCP negotiation,
+  could be performed using an eBPF program which could be attached from
+  userspace. Some information on this can be found in [an LWN
+  article](https://lwn.net/Articles/740157/).
+- It would be possible to attempt the use of multiple protocol features on the
+  first connection, falling back to trying each individually only if the first
+  connection fails. In some rare cases the use of a protocol feature can brick
+  the CPE or upstream middleboxes but this should either happen immediately or
+  never happen.
+
+## Examples
+
+- Censorship infrastructure was discovered using this technique in the EE
+  mobile operator network in the United Kingdom. See: I. R. Learmonth, A. Lutu,
+  G. Fairhurst, D. Ros and Ö. Alay, "[Path transparency measurements from the
+  mobile edge with
+  PATHspider](https://iain.learmonth.me/stuff/pubs/PATHspiderMobile2017.pdf),"
+  *2017 Network Traffic Measurement and Analysis Conference (TMA)*, Dublin, 2017,
+  pp. 1-6. doi:10.23919/TMA.2017.8002922
+
+## References
+
+- [RFC3168: The Addition of Explicit Congestion Notification (ECN) to IP](https://tools.ietf.org/html/rfc3168)
+
+## Implementations
+
+- An independent implementation exists for this technique in PATHspider's [ECN
+  plugin](https://pathspider.readthedocs.io/en/latest/plugins/ecn.html)

--- a/techniques/tq-xxx-attempt-h2-upgrade.md
+++ b/techniques/tq-xxx-attempt-h2-upgrade.md
@@ -1,0 +1,48 @@
+# tq-xxx Attempt upgrade to H2
+
+When a transparent HTTP proxy is in the path between the probe and the target
+server, an attempt to upgrade to H2 may reveal its presence in one of the
+following ways:
+
+1. The connection fails due to an unknown header being present
+2. The header is passed successfully to the server but the connection fails
+   because the reply using h2c was not understood by the proxy
+3. A server that is expected to negotiate h2 or h2c does not, or a server that
+   is not expected to negotiate h2 or h2c does
+
+When a transparent TLS proxy is in the path, it may reveal its presence in
+one of the following ways:
+
+1. Stripping the ALPN option which would cause h2 to not be negotiated where
+   expected
+2. The connection fails because the ALPN option is unknown
+
+## Methodology
+
+1. Fetch a webpage from a target server using either HTTP or HTTPS, with an H2
+   upgrade mechanism
+2. If the connection fails, retry the request without the use of the upgrade
+   mechanism to confirm that this was responsible for the connectivity failure,
+   and not just that the host was down
+
+## Implementation issues
+
+- It would be possible to attempt the use of multiple protocol features on the
+  first connection, falling back to trying each individually only if the first
+  connection fails. In some rare cases the use of a protocol feature can brick
+  the CPE or upstream middleboxes but this should either happen immediately or
+  never happen.
+
+## Examples
+
+- None yet
+
+## References
+
+- [Protocol upgrade mechanism](https://developer.mozilla.org/en-US/docs/Web/HTTP/Protocol_upgrade_mechanism) at MDN web docs
+- [RFC7540: Hypertext Transfer Protocol Version 2 (HTTP/2)](https://tools.ietf.org/html/rfc7540)
+
+## Implementations
+
+- An independent implementation exists for this technique in PATHspider's [H2
+  plugin](https://pathspider.readthedocs.io/en/latest/plugins/h2.html)

--- a/techniques/tq-xxx-attempt-tfo.md
+++ b/techniques/tq-xxx-attempt-tfo.md
@@ -1,0 +1,53 @@
+# tq-xxx Attempt use of TCP Fast Open
+
+When a transparent HTTP or TLS proxy is in the path between the probe and the
+target server, an attempt to use TCP fast open may reveal its presence in
+following ways:
+
+1. The connection fails due to an unknown TCP option being present
+2. The second connection fails due to data being present on the TCP SYN packet
+3. TCP fast open is not negotiated where expected, or is negotiated where it is
+   not expected
+
+## Methodology
+
+1. Fetch a webpage from a target server using either HTTP or HTTPS, using TCP
+   fast open to establish a TFO cookie
+2. If successful, fetch a webpage from the same server, again using TCP fast
+   open (this time will have data on the SYN)
+3. If the first connection failed, retry the request without the use of the TCP
+   fast open to confirm that this was responsible for the connectivity failure,
+   and not just that the host was down
+
+## Implementation issues
+
+- To confirm that TCP fast open usage was successful (negotiation and use of
+  TFO cookie) it is necessary to perform a packet capture, while failures
+  can be confirmed from the application layer feedback alone
+- Analysis of raw packets could be performed using an eBPF program which could
+  be attached from userspace. Some information on this can be found in [an LWN
+  article](https://lwn.net/Articles/740157/).
+- It would be possible to attempt the use of multiple protocol features on the
+  first connection, falling back to trying each individually only if the first
+  connection fails. In some rare cases the use of a protocol feature can brick
+  the CPE or upstream middleboxes but this should either happen immediately or
+  never happen.
+
+## Examples
+
+- None yet for TCP fast open, although this technique uses similar principles
+  to discover middleboxes as presented in: I. R. Learmonth, A. Lutu, G.
+  Fairhurst, D. Ros and Ö. Alay, "[Path transparency measurements from the mobile
+  edge with
+  PATHspider](https://iain.learmonth.me/stuff/pubs/PATHspiderMobile2017.pdf),"
+  *2017 Network Traffic Measurement and Analysis Conference (TMA)*, Dublin, 2017,
+  pp. 1-6. doi:10.23919/TMA.2017.8002922
+
+## References
+
+- [RFC7413: TCP Fast Open](https://tools.ietf.org/html/rfc7413)
+
+## Implementations
+
+- An independent implementation exists for this technique in PATHspider's [TFO
+  plugin](https://pathspider.readthedocs.io/en/latest/plugins/tfo.html)


### PR DESCRIPTION
This pull request adds three techniques from [PATHspider](https://pathspider.net/):

* Detecting middleboxes through ECN induced connectivity failure
* Detecting middleboxes through TCP fast open induced connectivity failure
* Detecting middleboxes through H2 upgrade mechanism induced connectivity failure

This was worked on at the MAMI Project's Active Measurement Hackathon in Aberdeen, Scotland.