### PR TITLE
Fix telegram spec to increase clarity

### DIFF
--- a/nettests/ts-020-telegram.md
+++ b/nettests/ts-020-telegram.md
@@ -59,9 +59,8 @@ we consider Telegram to be blocked:
   ]
 }
 ```
-
-The variable capturing whether, overall, we consider telegram to be
-blocked at TCP level is `telegram_tcp_blocking`.
+The key `telegram_tcp_blocking` is used to indicate if we believe telegram to be blocked at
+the TCP level.
 
 Regardless of the status of the TCP connectivity this test sends HTTP POST
 requests on ports 80 and 443 to all access points. If at least an HTTP request
@@ -85,8 +84,8 @@ returns back a response, we consider Telegram to not be blocked:
 }
 ```
 
-The variable capturing whether we believe that telegram is blocked at
-the HTTP level is `telegram_http_blocking`.
+The key `telegram_http_blocking` is used to indicate if we believe telegram to be blocked at
+the HTTP level.
 
 ## Telegram web version test
 

--- a/nettests/ts-020-telegram.md
+++ b/nettests/ts-020-telegram.md
@@ -60,10 +60,12 @@ we consider Telegram to be blocked:
 }
 ```
 
+The variable capturing whether, overall, we consider telegram to be
+blocked at TCP level is `telegram_tcp_blocking`.
+
 Regardless of the status of the TCP connectivity this test sends HTTP POST
-requests on ports 80 and 443 to all access points. If any HTTP requests do
-not get back a response from an access point IP then it is considered as
-blocked:
+requests on ports 80 and 443 to all access points. If at least an HTTP request
+returns back a response, we consider Telegram to not be blocked:
 
 ```json
 {
@@ -82,6 +84,9 @@ blocked:
     "response": null
 }
 ```
+
+The variable capturing whether we believe that telegram is blocked at
+the HTTP level is `telegram_http_blocking`.
 
 ## Telegram web version test
 


### PR DESCRIPTION
1. explicitly mention how the summary variables are computed, because that was left implicit

2. modify the spec to make it consistent with all existing implementations with respect to when we consider telegram to be blocked at the HTTP level (the previous wording was such that I could not decide what it meant). Both MK and ooni/probe-legacy start with setting Telegram blocked at the HTTP level and then unblock it if "successful". (I am profoundly skeptical that we can easily define success here without speaking the protocol, and without validating certificates, because in reality we may be speaking with any endpoint; also, in my limited tests, now Telegram does not respond with `501` anymore -- all of this tells us possible ways in which we can perhaps improve our Telegram implementation)

- - -

What I'd like @hellais to do as the reviewer:

- confirm that my interpretation of point 2. above is correct

- comment the limitations of the test and discuss with me possible follow ups