### PR TITLE
QUIC availability

### DIFF
--- a/techniques/tq-034-block-udp.md
+++ b/techniques/tq-034-block-udp.md
@@ -1,0 +1,105 @@
+# tq-034 UDP blocking and manipulation
+
+UDP is one of the two most widely used data transport protocols.
+Unfortunately, some ISPs or local network firewalls may decide to completely block UDP.
+By definition this is against [network neutrality](https://en.wikipedia.org/wiki/Net_neutrality).
+In addition, with the upcoming [HTTP/3](https://en.wikipedia.org/wiki/HTTP/3)
+protocol being based on [QUIC protocol](https://quicwg.org/) which itself is
+built on top of UDP, it is really important that UDP works.
+
+## Measurements
+
+The questions of interest further to be described in this document are if
+
+* UDP works on any random port,
+* UDP works on port `443`,
+* UDP datagrams were not modified,
+* UDP datagrams were not duplicated.
+
+## Methodology
+
+1. Run a UDP server.
+2. Send UDP datagrams to the server.
+3. Server echoes received datagrams.
+4. Client validates the response.
+
+NOTE, the tests MUST be excluded on port `53` which is used for DNS queries.
+DNS by itself might be manipulated in different ways and deserves a separate
+technique of its own. Hence is out of scope of this document.
+
+### UDP Server
+
+The same UDP server MAY be used for all measurements. UDP server is expected to
+be listening on
+
+1. multiple random ports from unprivileged port space - `1025..65535`. Say
+   3 arbitrary chosen ports;
+2. port `443`. HTTP/3 will be using UDP port `443`. So it is important to
+   specifically test, if this port is not blocked.
+
+All the server SHOULD do is echo received datagrams to the client that sent
+them.
+
+### UDP client
+
+The UDP test flow is as follows
+
+1. For each port in `[443, rand_port1, rand_port2, rand_port3]` send multiple
+   datagrams. One datagram is not enough because UDP datagrams might be
+   naturally lost on their way to the destination.
+   on their
+2. Generate random datagram of size <= 1400 bytes - no more than the usual
+   [MTU](https://en.wikipedia.org/wiki/Maximum_transmission_unit#IP_MTUs_for_common_media)
+   size. Each datagram must be random (unique), otherwise we won't be able to
+   detect UDP datagram duplication.
+3. Send the generated datagram to the server. Store the hashes of sent data
+   to specific endpoints (IP:port pair).
+4. Wait for up to 10 seconds for the response before declaring datagram as lost.
+5. In the meantime, keep receiving incoming responses and validate them by
+   hashing the payload of the datagram:
+5.1. check if echoed datagram was already sent, if it was not, that means
+     the tested network is modifying UDP datagrams;
+5.2. if it was, increase the count of received datagrams by its hash;
+6. Finally, traverse the collected data to form an appropriate measurement.
+   The resulting measurement MUST always separate `443` from random ports, e.g.:
+```json
+{
+  "443": "timeout",
+  "random": "ok",
+}
+```
+
+Pseudocode:
+
+```python
+sock = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
+# Keeps track of sent/received datagrams.
+sent_to = {}
+
+# Send multiple datagrams to different ports
+for port in [443, rand_port1, rand_port2, rand_port3]:
+    server_addr = (server_ip, port)
+    sent_to[server_addr] = {}
+
+    # Send 5 different datagrams to the same port
+    for _ in range(5):
+        data = rand_data(of_size=1400)
+
+        sock.sendto(data, server_addr)
+        # Initial result assigned to every request in case no response is
+        # received.
+        sent_to[server_addr][hash(data)] = Result.TIMEOUT
+
+while not timeout(10 secs):
+    (data, sender_addr) = sock.recvfrom()
+    if hash(data) in sent_to[server_addr]:
+        if sent_to[server_addr][hash(data)] == Result.TIMEOUT:
+            sent_to[server_addr][hash(data)] = Result.RECEIVED
+        else:
+            sent_to[server_addr][hash(data)] = Result.DUPLICATE
+    else:
+        # We did not send this datagram to this endpoint
+        sent_to[server_addr][hash(data)] = Result.MODIFIED
+
+# Traverse sent_to and format the result
+```

--- a/techniques/tq-035-block-quic.md
+++ b/techniques/tq-035-block-quic.md
@@ -1,0 +1,27 @@
+# tq-035 Blocking QUIC
+
+[QUIC](https://quicwg.org/) is a new transport protocol built on UDP. QUIC is
+a stream based protocol that provides congestion control, connection
+multiplexing, IP migration, data encryption, etc. In addition, it is expected
+to improve human rights on the Internet<sup>[1](#fn1)</sup>.
+HTTP is the fundamental Web protocol and QUIC is going to be used for the next
+version of HTTP - [HTTP/3](https://en.wikipedia.org/wiki/HTTP/3).
+To prepare for the future of the Web it is useful to understand
+how accessible QUIC is today. Unfortunately, there already exists discussions
+on blocking it among system administrators and ISPs <sup>[2](#fn2)</sup>
+<sup>[3](#fn3)</sup> <sup>[4](#fn4)</sup>.
+
+## Methodology
+
+1. Run a QUIC server listening on 443 and some random port(s).
+2. Send some random data over QUIC to all ports.
+3. Make the server simply echo the data.
+4. Wait for the data from the server and check if it matches the originally
+   sent one.
+
+## References
+
+1. <a name="fn1">https://tools.ietf.org/html/draft-martini-hrpc-quichr-00</a>
+2. <a name="fn2">https://www.reddit.com/r/paloaltonetworks/comments/6yqpjf/anyone_blocking_quic</a>
+3. <a name="fn3">https://www.reddit.com/r/networking/comments/9wriid/http3quic_and_the_yawning_abysmal_division</a>
+4. <a name="fn4">https://www.reddit.com/r/k12sysadmin/comments/9w9jdr/quic_protocol_to_block_or_not_to_block</a>


### PR DESCRIPTION
With this PR I'd like  to raise the awareness of importance for measuring QUIC availability. QUIC is the new transport protocol based on UDP - if UDP is blocked, QUIC will be blocked as well. So naturally it makes sense to split those measurements and execute them sequentially one after the other.

This PR is serves as a starting point and  merely adds two new techniques (UDP and QUIC blocking)  but does not include nettest and data format specs. Although, both should be pretty straightforward to document.

## Implementation notes

If QUIC blocking technique is accepted, I believe we can approach the implementation iteratively: 

1. start with the nettest and data format descriptions;
2. update measurement-kit to execute the tests;
3. update probe tools to integrate new measurements;
4. send data to collector where at a given time it could merely drop QUIC related measurements;
5. update data store schema to adapt to new QUIC related measurements;
6. update the API accordingly;
7. update the explorer;
8. anything else I missed.

Each step can be executed without breaking the subsequent step of data processing pipeline. 