### PR TITLE
ts-018-whatsapp.md: ack CIDR logic being broken

### DIFF
--- a/nettests/ts-018-whatsapp.md
+++ b/nettests/ts-018-whatsapp.md
@@ -80,7 +80,7 @@ consider the endpoint to be blocked and write in the report:
 }
 ```
 
-Since 2020-02-17, this methodology has started failing consistently as
+Since 2020-02-17, this consistency check has started failing consistently as
 documented in the bugs section at the end of this document.
 
 For every IP, both consistent and inconsistent, we then try to establish a TCP session to port `443`

--- a/nettests/ts-018-whatsapp.md
+++ b/nettests/ts-018-whatsapp.md
@@ -80,6 +80,9 @@ consider the endpoint to be blocked and write in the report:
 }
 ```
 
+Since 2020-02-17, this methodology has started failing consistently as
+documented in the bugs section at the end of this document.
+
 For every IP, both consistent and inconsistent, we then try to establish a TCP session to port `443`
 and `5222`.
 
@@ -555,4 +558,6 @@ WhatsApp as described in version 2016-10-25-001 of this specification is
 fundamentally broken (see [ooni/probe-engine#341](
 https://github.com/ooni/probe-engine/issues/341)). This issue affected
 ooni/probe-legacy <= 2.3.0, ooni/probe-ios <= 2.2.0, ooni/probe-android
-<= 2.2.0. 
+<= 2.2.0. The `test_version` was 0.6.0 for ooni/probe-legacy and 0.6.1
+for the mobile apps. Since Measurement Kit 0.10.10 (`test_version`
+0.7.0) we will completely disable such check.

--- a/nettests/ts-018-whatsapp.md
+++ b/nettests/ts-018-whatsapp.md
@@ -547,3 +547,12 @@ The meaning of the various keys is described in the above section.
     "test_version": "0.5.0"
 }
 ```
+
+## Bugs
+
+Since 2020-02-17, the heristics for checking whether a netblock belongs to
+WhatsApp as described in version 2016-10-25-001 of this specification is
+fundamentally broken (see [ooni/probe-engine#341](
+https://github.com/ooni/probe-engine/issues/341)). This issue affected
+ooni/probe-legacy <= 2.3.0, ooni/probe-ios <= 2.2.0, ooni/probe-android
+<= 2.2.0. 


### PR DESCRIPTION
It's probably wise to mention this in the spec because it has impacts on
the data quality, because most tests now result into an anomaly.

Tracking issue: https://github.com/ooni/probe-engine/issues/341.