### PR TITLE
Fix data formats versions and minor typos

### DIFF
--- a/data-formats/df-000-base.md
+++ b/data-formats/df-000-base.md
@@ -64,7 +64,7 @@ Connectivity experiment uses URLs as input.
 - `input_hashes` (`[]string`; optional; deprecated): historical field that
 used to contain the SHA256s of all inputs provided to the experiment. Modern
 implementations, e.g. Measurement Kit, typically emit an empty list. All
-clients using `v0.3.0`, or greater, of the data format SHOULD NOT emit this field at all.
+clients using `v0.2.1`, or greater, of the data format SHOULD NOT emit this field at all.
 
 - `measurement_start_time` (`string`): time when this measurement was
 started in UTC, using the `"2006-01-02 08:04:05"` format. Note that
@@ -73,7 +73,7 @@ ooniprobe <= 1.4.0 generates skewed time information.
 - `options` (`[]string`; optional; deprecated): list of options passed on the
 command line when running this specific experiment. Modern implementations,
 e.g. Measurement Kit, typically emit an empty list here. All clients using
-`v0.3.0` or greater of the data format SHOULD NOT emit this field at all.
+`v0.2.1` or greater of the data format SHOULD NOT emit this field at all.
 
 - `probe_asn` (`string`): AS Number of the probe (prefixed by AS, e.g.,
 `"AS1234"`), or `"AS0"` if the user does not want to share their ASN.
@@ -83,7 +83,7 @@ e.g. Measurement Kit, typically emit an empty list here. All clients using
 
 - `probe_city` (`string`; optional; deprecated): name of the city where the
 measurement was run. If the user does not want to share this information,
-this field should be set to `null` by `v0.2.0` clients. Clients using `v0.3.0`
+this field should be set to `null` by `v0.2.0` clients. Clients using `v0.2.1`
 or greater SHOULD NOT emit this field.
 
 - `probe_ip` (`string`): IP address of the probe, or `"127.0.0.1"` if
@@ -155,8 +155,8 @@ list of input URLs.
 ```
 
 Annotations is defined as `map[string]string` but the consumer of this field
-SHOULD NOT assume that clients using `data_format_version < 0.3.0` have always
-used string values. Since `v0.3.0` clients MUST always use string values. A
+SHOULD NOT assume that clients using `data_format_version < 0.2.1` have always
+used string values. Since `v0.2.1` clients MUST always use string values. A
 client SHOULD always add to the map of annotations:
 
   - `engine_name` (`string`): the name of the measurement engine

--- a/data-formats/df-001-httpt.md
+++ b/data-formats/df-001-httpt.md
@@ -69,7 +69,7 @@ for longer than that.
 `string` if it can be represented using UTF-8. Otherwise it is a `BinaryData`
 instance, as described below. See also `MaybeBinaryData` below.
 
-- `body_is_truncated` (`bool`; optional; since v0.3.0): `true` if the body
+- `body_is_truncated` (`bool`; optional; since v0.2.1): `true` if the body
 has been truncated, `false` or omitted otherwise.
 
 - `headers` (`map[string]MaybeBinaryData`): legacy map containing HTTP headers
@@ -77,9 +77,9 @@ where the value is `string` if it can be represented using UTF-8 and a
 `BinaryData` instance otherwise. In case multiple headers have the same key,
 the map SHOULD only contain the first value.
 
-- `headers_list` (`[]HeaderValue`); since v0.3.0): this is a better
+- `headers_list` (`[]HeaderValue`); since v0.2.1): this is a better
 representation of headers that allows us to represent the case where there
-are multple values for the same header key. See below the definion of
+are multiple values for the same header key. See below the definition of
 `HeaderValue`, which in the value-is-UTF-8 case boils down to the
 `[string, string]` tuple.
 


### PR DESCRIPTION
* Fix the version numbers errors of base and httpt data formats introduced
by 3203a0426e9798d7f87ed5180a7ed4ff017a7a03
* Fix minor spelling typos