### PR TITLE
whatsapp: improve spec to reduce false positives

### DIFF
--- a/data-formats/df-007-errors.md
+++ b/data-formats/df-007-errors.md
@@ -46,6 +46,12 @@ is not flagged, it means that it's used by all the three products.
 
 - `"http_request_failed"` (MK, PE): HTTP request did not return a successful response code
 
+- `"http_unexpected_redirect_url"` (PE): we expected a specific redirect URL and
+instead we saw either no redirect URL or a different redirect URL
+
+- `"http_unexpected_status_code"` (PE): we did not expected to see this status
+code (e.g. we expected a redirection and saw something else)
+
 - `"interrupted"` (PE): the user interrupted us by cancelling the context
 
 - `"response_never_received"` (PL): [t.w._newclient.ResponseNeverReceived](https://twistedmatrix.com/documents/15.4.0/api/twisted.web._newclient.ResponseNeverReceived.html)

--- a/nettests/ts-018-whatsapp.md
+++ b/nettests/ts-018-whatsapp.md
@@ -13,8 +13,8 @@ WhatsApp
 # Expected impact
 
 Ability to detect whether specific services used by WhatsApp are
-accessible and working as intended. Even if this test detect no
-issues, WhatsApp may still be blocked in more complex ways.
+accessible and working as intended. Even if this test does not detect
+any issue, WhatsApp may still be blocked in more complex ways.
 
 # Expected inputs
 


### PR DESCRIPTION
Specifically, say that WhatsApp web is reachable over HTTPS regardless
of the HTTP status code and that over HTTP we're happy if we get a
redirect to the correct location.

This is part of https://github.com/ooni/probe-engine/issues/740.

While there, remove the all endpoints option. We should test all the
endpoints to make a better statement on whether it's blocked.

(A single endpoint down is, in fact, a false positive.)

While there, explicitly say that the CIDR check is gone for good,
since it has not been working for quite some time now.

While there, mention all the parent data formats and specify the
toplevel structure in a more strict way.