### PR TITLE
fix(webconnectivity): document network events and tls handshakes

### DIFF
--- a/data-formats/df-006-tlshandshake.md
+++ b/data-formats/df-006-tlshandshake.md
@@ -28,6 +28,7 @@ code. See this directory's [README](README.md) for the basic concepts.
     "negotiated_protocol": "",
     "peer_certificates": [],
     "t": 1.11,
+    "tags": [],
     "tls_version": "",
     "transaction_id": 1
 }
@@ -49,6 +50,9 @@ in `df-001-httpt.md`.
 
 - `t` (`float`): number of seconds elapsed since `measurement_start_time`
 measured in the moment in which `failure` is determined.
+
+- `tags` (`[]string`): list of tags for this event. This is useful to
+understand what part of a complex measurement generated an event.
 
 - `tls_version` (`string`): the negotiated TLS version, if any.
 

--- a/data-formats/df-008-netevents.md
+++ b/data-formats/df-008-netevents.md
@@ -30,6 +30,7 @@ MAY use to include network-level events. See this directory's
     "operation": "read",
     "proto": "tcp",
     "t": 1.174,
+    "tags": [],
     "transaction_id": 1
 }
 ```
@@ -55,6 +56,9 @@ a string indicating the error, otherwise it MUST be `null`.
 
 - `t` (`float`): number of seconds elapsed since `measurement_start_time`
 measured when `operation` is complete.
+
+- `tags` (`[]string`): list of tags for this event. This is useful to
+understand what part of a complex measurement generated an event.
 
 - `transaction_id` (`int`; optional; since 2020-01-11): if present, this is the
 ID of the HTTP transaction that caused this TCP connect.
@@ -88,6 +92,7 @@ not relevant to the netevents data format:
             "operation": "connect",
             "proto": "tcp",
             "t": 0.11,
+            "tags": ["tcptls_experiment"],
             "transaction_id": 1
         }, {
             "address": "1.1.1.1:443",
@@ -97,19 +102,22 @@ not relevant to the netevents data format:
             "operation": "connect",
             "proto": "tcp",
             "t": 0.16,
+            "tags": ["tcptls_experiment"],
             "transaction_id": 1
         }, {
             "conn_id": 12,
             "failure": null,
             "num_bytes": 1024,
             "operation": "write",
-            "t": 0.17
+            "t": 0.17,
+            "tags": ["tcptls_experiment"]
         }, {
             "conn_id": 12,
             "failure": null,
             "num_bytes": 5110,
             "operation": "read",
-            "t": 0.44
+            "t": 0.44,
+            "tags": ["tcptls_experiment"]
         }]
     }
 }

--- a/nettests/ts-017-web-connectivity.md
+++ b/nettests/ts-017-web-connectivity.md
@@ -38,7 +38,7 @@ URLs may contain IP addresses rather than domain names.
 This test is divided into multiple steps that will each test a different aspect
 related to connectivity of the website in question.
 
-We describe the steps below. And orthogonal
+We describe the steps below. An orthogonal
 step is to inform the web_connectivity test helper of our intention
 to run the measurement against the URL in question and hence have it perform a
 control measurement from an un-censored vantage point.
@@ -141,7 +141,7 @@ The experiment itself consists of the following steps:
       connections (if applicable)?
 
       The value of the report key "tcp_connect" will be a list with 1 item per
-      IP:port combination. This value will follow df-005-tcpconnect with
+      IP:port combination. This value will follow `df-005-tcpconnect` with
       the addition of the "blocked" flag.
 
       In particular, "blocked" shall be

--- a/nettests/ts-017-web-connectivity.md
+++ b/nettests/ts-017-web-connectivity.md
@@ -95,7 +95,9 @@ The experiment itself consists of the following steps:
    Optionally, if the URL beings with HTTPS then also perform a TLS
    handshake using the above established connections. The results
    of the TLS handshake end up in the "tls_handshakes" key
-   (see df-006-tlshandshake.md). This is the behavior of ooniprobe
+   (see df-006-tlshandshake.md). We will tag network events and
+   TLS handshakes produced by this step of the experiment
+   using the `"tcptls_experiment"` tag. This is the behavior of ooniprobe
    3.x since August 2020.
 
    Probes SHOULD also record the network events (see df-netevents.md)


### PR DESCRIPTION
The related issue is https://github.com/ooni/probe-engine/issues/1157.

While there, I also lightly edited the specification to reference
existing data formats and to increase its adherence to the real
implementation we are using.

I look forward to further improve this specification as I continue
to work on the topic of improving Web Connectivity.