### PR TITLE
Issue/2061 : torsf default timeout

### DIFF
--- a/nettests/ts-030-torsf.md
+++ b/nettests/ts-030-torsf.md
@@ -86,6 +86,7 @@ considered as a failure to start the test up;
 ```JSON
 {
     "bootstrap_time": 1.1,
+    "default_timeout": 600,
     "failure": null,
     "persistent_datadir": true,
     "rendezvous_method": "domain_fronting",
@@ -98,6 +99,8 @@ where:
 
 - `bootstrap_time` (`float`) is zero if the bootstrap times out and otherwise is
 the number of seconds it required to bootstrap;
+
+- `default_timeout` (`float`) is the default timeout for the experiment;
 
 - `failure` conforms to `df-007-errors`;
 
@@ -140,6 +143,7 @@ the [data analysis considerations](#data-analysis-considerations) section below.
   "software_version": "3.14.0-alpha.1",
   "test_keys": {
     "bootstrap_time": 316.569053291,
+    "default_timeout": 600,
     "failure": null,
     "persistent_datadir": true,
     "rendezvous_method": "domain_fronting",

--- a/nettests/ts-030-torsf.md
+++ b/nettests/ts-030-torsf.md
@@ -1,6 +1,6 @@
 # Specification version number
 
-2022-02-07-002
+2022-04-12-003
 
 * _status_: experimental
 

--- a/nettests/ts-030-torsf.md
+++ b/nettests/ts-030-torsf.md
@@ -100,7 +100,7 @@ where:
 - `bootstrap_time` (`float`) is zero if the bootstrap times out and otherwise is
 the number of seconds it required to bootstrap;
 
-- `default_timeout` (`float`) is the default timeout for the experiment;
+- `default_timeout` (`float`) is the default timeout for the experiment (in seconds);
 
 - `failure` conforms to `df-007-errors`;
 


### PR DESCRIPTION
## Checklist

- [x] I have read the [contribution guidelines](https://github.com/ooni/spec/blob/master/CONTRIBUTING.md)
- [x] reference issue for this pull request: [Issue #2061](https://github.com/ooni/probe/issues/2061)
- [x] reference PR for probe-cli: [PR #709](https://github.com/ooni/probe-cli/pull/709) 
- [x] If I changed a spec, I also bumped its version number and/or date

## Description

Added default_timeout field for the torsf measurement result for better understanding of users.
