### PR TITLE
df-001-httpt.md: clarify socksproxy field meaning

### DIFF
--- a/data-formats/df-001-httpt.md
+++ b/data-formats/df-001-httpt.md
@@ -24,7 +24,7 @@ follow redirects, set to `redirect` otherwise.
 - `request` (`[]Transaction`): list of transaction objects. See below.
 
 - `socksproxy` (`string`; optional): address of the SOCKS proxy being
-used. Omit or set to `null` if no SOCKS proxy is being used. The format
+used in a nettest. Note that this proxy is different from the one used to contact the backend. Omit or set to `null` if no SOCKS proxy is being used. The format
 to be used is `1.2.3.4:54321` for IPv4 and `[::1234]:54321` for IPv6.
 
 ## Transaction

--- a/data-formats/df-001-httpt.md
+++ b/data-formats/df-001-httpt.md
@@ -6,7 +6,7 @@ code. See this directory's [README](README.md) for the basic concepts.
 
 | Name       | `httpt` |
 |------------|---------|
-| Version    | 0       |
+| Version    | 1       |
 
 ## Specification
 

--- a/data-formats/df-001-httpt.md
+++ b/data-formats/df-001-httpt.md
@@ -6,7 +6,7 @@ code. See this directory's [README](README.md) for the basic concepts.
 
 | Name       | `httpt` |
 |------------|---------|
-| Version    | 1       |
+| Version    | 0       |
 
 ## Specification
 


### PR DESCRIPTION
## Checklist

- [x] I have read the [contribution guidelines](https://github.com/ooni/spec/blob/master/CONTRIBUTING.md)
- [x] reference issue for this pull request: https://github.com/ooni/probe/issues/1947
- [ ] related ooni/probe-cli pull request
- [x] If I changed a spec, I also bumped its version number and/or date

Location of the issue tracker: https://github.com/ooni/probe

## Description

The `socksproxy` field is only set when a nettest uses a SOCKS proxy. This is different from the SOCKS proxy used to contact the backend. Clarifications have been added to `df-001-httpt.md`.
