### PR TITLE
refactor(datafmt): use "udp" instead of "quic"

### DIFF
--- a/data-formats/df-001-httpt.md
+++ b/data-formats/df-001-httpt.md
@@ -49,7 +49,7 @@ probes always set this field to `null`.
 underlying connection we are using: either `"tcp"` or `"udp"`. Until 2022-09-08, we used
 `"tcp"` or `"quic"` but we realized that using `"udp"` instead of `"quic"` would
 be more consistent, so we also changed `"quic"` to always become `"udp"`. These
-changes occurred between during the OONI Probe v3.16.0 release cycle in
+changes occurred during the OONI Probe v3.16.0 release cycle in
 [ooni/probe-cli#946](https://github.com/ooni/probe-cli/pull/946).
 
 - `address` (`string`; optional): if available, the endpoint of the
@@ -126,7 +126,7 @@ instance of `tor` that we may be using for measuring.
 issuing the request. Typically `"tcp"` or `"udp"`. Until 2022-09-08, we used
 `"tcp"` or `"quic"` but we realized that using `"udp"` instead of `"quic"` would
 be more consistent, so we also changed `"quic"` to always become `"udp"`. These
-changes occurred between during the OONI Probe v3.16.0 release cycle in
+changes occurred during the OONI Probe v3.16.0 release cycle in
 [ooni/probe-cli#946](https://github.com/ooni/probe-cli/pull/946).
 
 In case we have the following headers:

--- a/data-formats/df-001-httpt.md
+++ b/data-formats/df-001-httpt.md
@@ -46,7 +46,7 @@ probes always set this field to `null`.
 ```
 
 - `network` (`string`; optional): if available, the network of the
-underlying connection we are using: either `"tcp"` or `"quic"`.
+underlying connection we are using: either `"tcp"` or `"udp"`.
 
 - `address` (`string`; optional): if available, the endpoint of the
 underlying connection we are using (e.g., `"[::1]:443"`).
@@ -119,7 +119,11 @@ are multiple values for the same header key. See below the definition of
 instance of `tor` that we may be using for measuring.
 
 - `x_transport` (`string`; deprecated): indicates what transports was used for
-issuing the request. Typically `"tcp"` or `"quic"`.
+issuing the request. Typically `"tcp"` or `"udp"`. Until 2022-09-08, we used
+`"tcp"` or `"quic"` but we realized that using `"udp"` instead of `"quic"` would
+be more consistent, so we also changed `"quic"` to always become `"udp"`. These
+changes occurred between during the OONI Probe v3.16.0 release cycle in
+[ooni/probe-cli#946](https://github.com/ooni/probe-cli/pull/946).
 
 In case we have the following headers:
 

--- a/data-formats/df-001-httpt.md
+++ b/data-formats/df-001-httpt.md
@@ -46,7 +46,11 @@ probes always set this field to `null`.
 ```
 
 - `network` (`string`; optional): if available, the network of the
-underlying connection we are using: either `"tcp"` or `"udp"`.
+underlying connection we are using: either `"tcp"` or `"udp"`. Until 2022-09-08, we used
+`"tcp"` or `"quic"` but we realized that using `"udp"` instead of `"quic"` would
+be more consistent, so we also changed `"quic"` to always become `"udp"`. These
+changes occurred between during the OONI Probe v3.16.0 release cycle in
+[ooni/probe-cli#946](https://github.com/ooni/probe-cli/pull/946).
 
 - `address` (`string`; optional): if available, the endpoint of the
 underlying connection we are using (e.g., `"[::1]:443"`).

--- a/data-formats/df-006-tlshandshake.md
+++ b/data-formats/df-006-tlshandshake.md
@@ -41,7 +41,7 @@ code. See this directory's [README](README.md) for the basic concepts.
 2022-09-08, we incorrectly documented that this could have been either `"tls"` or `"quic"` but
 the code always used `"tcp"`, so we adapted the spec to the code. On the same day, we also
 realized that using `"udp"` instead of `"quic"` would be more consistent, so we also changed
-`"quic"` to always become `"udp"`. These changes occurred between during the OONI Probe
+`"quic"` to always become `"udp"`. These changes occurred during the OONI Probe
 v3.16.0 release cycle in [ooni/probe-cli#946](https://github.com/ooni/probe-cli/pull/946).
 
 - `address` (`string`): The endpoint IP address (host:port) with which the handshake is performed.

--- a/data-formats/df-006-tlshandshake.md
+++ b/data-formats/df-006-tlshandshake.md
@@ -37,9 +37,12 @@ code. See this directory's [README](README.md) for the basic concepts.
     "transaction_id": 1
 }
 ```
-- `network` (`string`; optional): The network for the handshake (`"tcp"` or `"quic"`). Until
+- `network` (`string`; optional): The network for the handshake (`"tcp"` or `"udp"`). Until
 2022-09-08, we incorrectly documented that this could have been either `"tls"` or `"quic"` but
-the code always used `"tcp"`, so we adapted the spec to the code.
+the code always used `"tcp"`, so we adapted the spec to the code. On the same day, we also
+realized that using `"udp"` instead of `"quic"` would be more consistent, so we also changed
+`"quic"` to always become `"udp"`. These changes occurred between during the OONI Probe
+v3.16.0 release cycle in [ooni/probe-cli#946](https://github.com/ooni/probe-cli/pull/946).
 
 - `address` (`string`): The endpoint IP address (host:port) with which the handshake is performed.
 

--- a/nettests/ts-034-simplequicping.md
+++ b/nettests/ts-034-simplequicping.md
@@ -65,7 +65,7 @@ where:
 
 Before 2022-08-06, `quic_handshake` was a list but we
 changed that because this is an experimental nettest and it seems better
-to avoid suggesting there could be more than a single QUIC handshake for 
+to avoid suggesting there could be more than a single QUIC handshake for
 each ping
 
 ## Possible conclusions
@@ -211,7 +211,7 @@ from its results but it is useful to perform censorship research.
           }
         ],
         "quic_handshake": {
-          "network": "quic",
+          "network": "udp",
           "address": "8.8.8.8:443",
           "cipher_suite": "TLS_CHACHA20_POLY1305_SHA256",
           "failure": null,
@@ -347,7 +347,7 @@ from its results but it is useful to perform censorship research.
           }
         ],
         "quic_handshake": {
-          "network": "quic",
+          "network": "udp",
           "address": "8.8.8.8:443",
           "cipher_suite": "TLS_CHACHA20_POLY1305_SHA256",
           "failure": null,
@@ -483,7 +483,7 @@ from its results but it is useful to perform censorship research.
           }
         ],
         "quic_handshake": {
-          "network": "quic",
+          "network": "udp",
           "address": "8.8.8.8:443",
           "cipher_suite": "TLS_CHACHA20_POLY1305_SHA256",
           "failure": null,
@@ -619,7 +619,7 @@ from its results but it is useful to perform censorship research.
           }
         ],
         "quic_handshake": {
-          "network": "quic",
+          "network": "udp",
           "address": "8.8.8.8:443",
           "cipher_suite": "TLS_CHACHA20_POLY1305_SHA256",
           "failure": null,
@@ -755,7 +755,7 @@ from its results but it is useful to perform censorship research.
           }
         ],
         "quic_handshake": {
-          "network": "quic",
+          "network": "udp",
           "address": "8.8.8.8:443",
           "cipher_suite": "TLS_CHACHA20_POLY1305_SHA256",
           "failure": null,
@@ -891,7 +891,7 @@ from its results but it is useful to perform censorship research.
           }
         ],
         "quic_handshake": {
-          "network": "quic",
+          "network": "udp",
           "address": "8.8.8.8:443",
           "cipher_suite": "TLS_CHACHA20_POLY1305_SHA256",
           "failure": null,
@@ -1019,7 +1019,7 @@ from its results but it is useful to perform censorship research.
           }
         ],
         "quic_handshake": {
-          "network": "quic",
+          "network": "udp",
           "address": "8.8.8.8:443",
           "cipher_suite": "TLS_CHACHA20_POLY1305_SHA256",
           "failure": null,
@@ -1155,7 +1155,7 @@ from its results but it is useful to perform censorship research.
           }
         ],
         "quic_handshake": {
-          "network": "quic",
+          "network": "udp",
           "address": "8.8.8.8:443",
           "cipher_suite": "TLS_CHACHA20_POLY1305_SHA256",
           "failure": null,
@@ -1291,7 +1291,7 @@ from its results but it is useful to perform censorship research.
           }
         ],
         "quic_handshake": {
-          "network": "quic",
+          "network": "udp",
           "address": "8.8.8.8:443",
           "cipher_suite": "TLS_CHACHA20_POLY1305_SHA256",
           "failure": null,
@@ -1427,7 +1427,7 @@ from its results but it is useful to perform censorship research.
           }
         ],
         "quic_handshake": {
-          "network": "quic",
+          "network": "udp",
           "address": "8.8.8.8:443",
           "cipher_suite": "TLS_CHACHA20_POLY1305_SHA256",
           "failure": null,


### PR DESCRIPTION
See https://github.com/ooni/probe-cli/pull/946 where we also explain why we're doing this change.

Reference issue: https://github.com/ooni/probe/issues/2238
