### PR TITLE
df-005-tcpconnect: mention old probes setting failure to false

### DIFF
--- a/data-formats/df-005-tcpconnect.md
+++ b/data-formats/df-005-tcpconnect.md
@@ -83,7 +83,8 @@ SHOULD NOT use this field and SHOULD instead use distinct keys to represent
 network observations and the probe's analysis.
 
 - `failure` (`string`; nullable): if there was an error, this field is
-a string indicating the error, otherwise it MUST be `null`. Some older versions of OONI Probe set this to `false` instead of NULL.
+a string indicating the error, otherwise it MUST be `null`. Some older versions of OONI Probe
+set this to `false` instead of `null`.
 
 - `success` (`bool`): true if failure is `null`, false otherwise.
 

--- a/data-formats/df-005-tcpconnect.md
+++ b/data-formats/df-005-tcpconnect.md
@@ -83,7 +83,7 @@ SHOULD NOT use this field and SHOULD instead use distinct keys to represent
 network observations and the probe's analysis.
 
 - `failure` (`string`; nullable): if there was an error, this field is
-a string indicating the error, otherwise it MUST be `null`.
+a string indicating the error, otherwise it MUST be `null`. Some older versions of OONI Probe set this to `false` instead of NULL.
 
 - `success` (`bool`): true if failure is `null`, false otherwise.
 


### PR DESCRIPTION
Example of a measurement showing this behaviour: https://explorer.ooni.org/m/20210101003640.413492_AR_telegram_ad086fbac780bdae

## Checklist

- [ ] I have read the [contribution guidelines](https://github.com/ooni/spec/blob/master/CONTRIBUTING.md)
- [ ] reference issue for this pull request: <!-- add URL here -->
- [ ] related ooni/probe-cli pull request: <!-- add URL here -->
- [ ] If I changed a spec, I also bumped its version number and/or date

<!-- Location of the issue tracker: https://github.com/ooni/probe -->

## Description

Please, insert here a more detailed description.
