### PR TITLE
fix(web-connectivity): create examples section

### DIFF
--- a/nettests/ts-017-web-connectivity.md
+++ b/nettests/ts-017-web-connectivity.md
@@ -297,6 +297,25 @@ matches with the control (http-diff) or if the HTTP response failed
   tampering, TCP connection RST/IP blocking or by having a transparent HTTP
   proxy.
 
+*Note*: the control will set `body_length` and `status_code` to `-1` in
+case of failure. The client code must correctly handle this case.
+
+## Limitations
+
+Web Connectivity does not correctly handle server-side blocking with `http://` like URLs, as
+documented by [ooni/probe#2661](https://github.com/ooni/probe/issues/2661).
+
+## Privacy considerations
+
+If the client has opted out of providing the ASN of their probe the
+client_resolver key may give away extra information pertaining to the network
+they are on if they are using the resolver of their ISP. (Modern probes do
+not allow users to opt-out of providing their ANSs because that would
+lead to non-actionable measurements. It can still occurr that the ASN is
+set to zero if the ANS resolution mechanism failed.)
+
+## Examples
+
 ### Example control request and response
 
 Request:
@@ -363,9 +382,6 @@ Response:
     }
 }
 ```
-
-*Note*: the control will set `body_length` and `status_code` to `-1` in
-case of failure. The client code must correctly handle this case.
 
 ### Example output sample
 
@@ -772,17 +788,3 @@ case of failure. The client code must correctly handle this case.
   "test_version": "0.4.0"
 }
 ```
-
-## Limitations
-
-Web Connectivity does not correctly handle server-side blocking with `http://` like URLs, as
-documented by [ooni/probe#2661](https://github.com/ooni/probe/issues/2661).
-
-## Privacy considerations
-
-If the client has opted out of providing the ASN of their probe the
-client_resolver key may give away extra information pertaining to the network
-they are on if they are using the resolver of their ISP. (Modern probes do
-not allow users to opt-out of providing their ANSs because that would
-lead to non-actionable measurements. It can still occurr that the ASN is
-set to zero if the ANS resolution mechanism failed.)

--- a/nettests/ts-017-web-connectivity.md
+++ b/nettests/ts-017-web-connectivity.md
@@ -297,9 +297,6 @@ matches with the control (http-diff) or if the HTTP response failed
   tampering, TCP connection RST/IP blocking or by having a transparent HTTP
   proxy.
 
-*Note*: the control will set `body_length` and `status_code` to `-1` in
-case of failure. The client code must correctly handle this case.
-
 ## Limitations
 
 Web Connectivity does not correctly handle server-side blocking with `http://` like URLs, as
@@ -382,6 +379,9 @@ Response:
     }
 }
 ```
+
+*Note*: the control will set `body_length` and `status_code` to `-1` in
+case of failure. The client code must correctly handle this case.
 
 ### Example output sample
 


### PR DESCRIPTION
The examples regarding the data format take lots of space and make reading the specification difficult possibly causing readers to miss important sections available near the end.

As a fix, move all the examples at the end in its own section.

See https://github.com/ooni/probe/issues/2666

