### PR TITLE
docs: try to be more precise about interval

### DIFF
--- a/data-formats/df-008-netevents.md
+++ b/data-formats/df-008-netevents.md
@@ -64,8 +64,11 @@ measured in the moment in which we started the operation (`t - t0` gives you
 the amount of time spent performing the operation);
 
 - `t` (`float`): number of seconds elapsed since `measurement_start_time`
-measured in the moment in which `failure` is determined (`t - t0` gives you
-the amount of time spent performing the operation);
+measured at the end of the operation at hand. If there was an error, this is the
+moment in which `failure` is determined; otherwise it's the moment marked by the successfully
+completion of the operation: as an example, consider a blocking call to `read`
+or `write`. In any case, `t - t0` gives you the amount of time spent performing
+the operation;
 
 - `tags` (`[]string`): list of tags for this event. This is useful to
 understand what part of a complex measurement generated an event.


### PR DESCRIPTION
the previous phrasing could induce to think that `t` is only measured in the case of failures.

## Checklist

- [x] I have read the [contribution guidelines](https://github.com/ooni/spec/blob/master/CONTRIBUTING.md)
- [x] reference issue for this pull request: NA
- [x] related ooni/probe-cli pull request: NA
- [x] If I changed a spec, I also bumped its version number and/or date
