### PR TITLE
fix: synchronize telegram IPs with engine

### DIFF
--- a/nettests/ts-020-telegram.md
+++ b/nettests/ts-020-telegram.md
@@ -42,6 +42,7 @@ These access points have the following IP addresses:
 * 149.154.175.100
 * 149.154.167.91
 * 149.154.171.5
+* 95.161.76.100
 
 The test establishes TCP connection to all the access point IP addresses and
 then attempts to issue a POST HTTP request to each of them.


### PR DESCRIPTION
## Checklist

- [x] I have read the [contribution guidelines](https://github.com/ooni/spec/blob/master/CONTRIBUTING.md)
- [x] https://github.com/ooni/probe/issues/2742
- [ ] related ooni/probe-cli pull request: <!-- add URL here -->
- [ ] If I changed a spec, I also bumped its version number and/or date

## Description

This diff updates the telegram nettest spec to include the latest IP endpoints we measure as part of the test
