### PR TITLE
Update link to list of DCs in Telegram desktop client

### DIFF
--- a/nettests/ts-020-telegram.md
+++ b/nettests/ts-020-telegram.md
@@ -33,7 +33,7 @@ This test will check if 2 services are working as they should:
 
 ## Telegram access points check
 
-The Telegram access points (DCs) are those used by the [Telegram desktop client](https://github.com/telegramdesktop/tdesktop/blob/e6d94b5ee7d96a97ee5976dacb87bafd00beac1d/Telegram/SourceFiles/config.h#L205).
+The Telegram access points (DCs) are those used by the [Telegram desktop client](https://github.com/telegramdesktop/tdesktop/blob/520de600a0ee4edaf0a8047ba6fb0371a7e3d939/Telegram/SourceFiles/mtproto/mtproto_dc_options.cpp#L31).
 
 These access points have the following IP addresses:
 


### PR DESCRIPTION
 #294 updated the list of IP addresses, but the link was still pointing to a 7-year-old source code file that was missing 95.161.76.100.

See discussion at https://github.com/net4people/bbs/issues/389#issuecomment-2310626450.

## Checklist

- [x] I have read the [contribution guidelines](https://github.com/ooni/spec/blob/master/CONTRIBUTING.md)
- [x] reference issue for this pull request: https://github.com/ooni/probe/issues/2742
- [x] related ooni/probe-cli pull request: https://github.com/ooni/probe-engine/issues/999
- [x] If I changed a spec, I also bumped its version number and/or date